### PR TITLE
fix: github-button-changes-to-dark-mode

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -52,7 +52,6 @@ function Header({ toggleTheme, isDarkMode }) {
               style={{ marginLeft: "2rem", marginTop: "1rem" }}
             >
               <IconButton
-                onClick={toggleTheme}
                 sx={{ color: theme.palette.text.primary }}
               >
                 <GitHub />


### PR DESCRIPTION
Github Button doesn't change to dark mode anymore.