### PR TITLE
fix: ignoring prefixes within the path like /en/

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ Deeplinks are available for the following endpoints:
 - `Transaction` - URL `explorer.cardano.org/transaction?id={TRANSACTION_ID}` or `explorer.cardano.org/transaction/{TRANSACTION_ID}`
 - `Address` - URL `explorer.cardano.org/address?address={ADDRESS}` or `explorer.cardano.org/address/{ADDRESS}`
 
-Additionally, to the above functions it is possible to specify which network to use. This can be done by adding a query parameter `network` to the URL. The following networks are supported:
+Additionally, to the above functions it is possible to specify which network to use. The following networks are supported:
 - `mainnet` - Default network, no need to specify
-- `preprod` - `explorer.cardano.org/?network=preprod`
-- `preview` - `explorer.cardano.org/?network=preview`
+- `preprod` - `explorer.cardano.org/?network=preprod` or `explorer.cardano.org/preprod`
+- `preview` - `explorer.cardano.org/?network=preview` or `explorer.cardano.org/preview`
 
 A full example for a transaction would be:
 `explorer.cardano.org/transaction?id=1234567890&network=preprod`

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -217,7 +217,7 @@ const CardanoExplorer = () => {
                 </Alert>
               </Grid>
             )}
-            {deepLinkResolver.network !== null && (
+            {(deepLinkResolver.network !== undefined) && (
                 <Grid item xs={12}>
                   <Alert
                       severity={"info"}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -72,8 +72,8 @@ const CardanoExplorer = () => {
 
   const query = useQuery();
   const path = useLocation().pathname;
-  const isDeepLink = path.replace("/", "").length > 0;
   const deepLinkResolver = new DeepLinkResolver(path, query);
+  const isDeepLink = deepLinkResolver.isDeepLink(path);
 
   const listOfExplorers = {
     cExplorer: {

--- a/src/common/DeepLinkResolver.jsx
+++ b/src/common/DeepLinkResolver.jsx
@@ -20,9 +20,6 @@ class DeepLinkResolver {
         return this.acceptedDeepLinks.includes(item);
     });
 
-    if(pathSplit[index].length === 0) {
-        pathSplit.shift();
-    }
     this.mode = pathSplit[index] === "tx" ? "transaction" : pathSplit[index];
     // if the path is /tx?id=1234, we need to split the path and get the id from the query
     // if the path is /tx/1234, we need to split the path and get the id from the path
@@ -41,6 +38,8 @@ class DeepLinkResolver {
         case "address":
           this.query.set("address", pathSplit[pathSplit.length - 1]);
           break;
+        default:
+          console.log("Unknown mode: " + this.mode);
       }
     } else {
       this.query = query;
@@ -166,6 +165,11 @@ class DeepLinkResolver {
 
   canHandleNetwork(networks) {
     return this.network === undefined || this.network === null || networks.includes(this.network);
+  }
+
+  isDeepLink(path) {
+    const filteredPath = path.replace("/", "");
+    return filteredPath.length > 0 && !this.acceptedNetworks.includes(filteredPath);
   }
 }
 

--- a/src/common/DeepLinkResolver.jsx
+++ b/src/common/DeepLinkResolver.jsx
@@ -8,7 +8,7 @@ const screens = Object.freeze({
 
 class DeepLinkResolver {
   acceptedDeepLinks = ["transaction", "block", "epoch", "address", "tx"];
-  acceptedNetworks = ["mainnet", "preprod", "preview"];
+  acceptedNetworks = ["preprod", "preview"]; // mainnet is default
 
 
   constructor(path, query) {
@@ -45,7 +45,14 @@ class DeepLinkResolver {
     } else {
       this.query = query;
     }
-    this.network = this.query.get("network");
+    // Network can be set like ?network=preprod or /preprod/tx?id=1234
+    if(query.has("network")) {
+      this.network = query.get("network");
+    }
+    let findIndex = pathSplit.findIndex((item => this.acceptedNetworks.includes(item)));
+    if(findIndex !== -1) {
+      this.network = pathSplit[findIndex];
+    }
   }
 
   getCExplorerLink (baseLink) {


### PR DESCRIPTION
This PR implements a filtering of the path to avoid unexepected behaviour if prefixes like `/en/` are added. Localization isn't supported and we must ignore it. 
Path's like `explorer.cardano.org/en/transaction?id=....` is now working as expected.