### PR TITLE
feat: support deeplink to governance actions.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,12 +7,13 @@
     "": {
       "name": "cf-explorer-landing",
       "version": "1.0.0",
-      "license": "ISC",
+      "license": "Apache-2.0",
       "dependencies": {
         "@emotion/react": "^11.13.0",
         "@emotion/styled": "^11.13.0",
         "@mui/icons-material": "^5.16.7",
         "@mui/material": "^5.16.7",
+        "bech32": "^2.0.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-router-dom": "^6.26.0"
@@ -1436,6 +1437,11 @@
         "node": ">=10",
         "npm": ">=6"
       }
+    },
+    "node_modules/bech32": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
+      "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg=="
     },
     "node_modules/browserslist": {
       "version": "4.23.3",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@emotion/styled": "^11.13.0",
     "@mui/icons-material": "^5.16.7",
     "@mui/material": "^5.16.7",
+    "bech32": "^2.0.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.26.0"

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -75,14 +75,16 @@ const CardanoExplorer = () => {
   const deepLinkResolver = new DeepLinkResolver(path, query);
   const isDeepLink = deepLinkResolver.isDeepLink(path);
 
+  const cExplorerDeepLink = deepLinkResolver.getCExplorerLink("https://cexplorer.io/");
+
   const listOfExplorers = {
     cExplorer: {
       name: "Cexplorer.io",
       description:
         "Ideal for those who need comprehensive data on Cardano's blockchain thanks to its robust analytical tools.",
       image: cExplorerLogo,
-      url: deepLinkResolver.getCExplorerLink("https://cexplorer.io/"),
-      isDeepLink: true,
+      url: cExplorerDeepLink ? cExplorerDeepLink : "https://cexplorer.io/",
+      isDeepLink: cExplorerDeepLink != null,
       networks: ["preprod", "preview"]
     },
     cardanoScan: {
@@ -212,7 +214,7 @@ const CardanoExplorer = () => {
                     borderRadius: "16px",
                   }}
                 >
-                  You will be forwarded to <strong>{deepLinkResolver.mode} {deepLinkResolver.getValue()}{" "}</strong>
+                  You will be forwarded to <strong>{deepLinkResolver.getHumanReadableMode()} {deepLinkResolver.getValue()}{" "}</strong>
                   after choosing your favorite Explorer
                 </Alert>
               </Grid>

--- a/src/common/DeepLinkResolver.jsx
+++ b/src/common/DeepLinkResolver.jsx
@@ -1,3 +1,4 @@
+import { bech32 } from "bech32";
 import React from "react";
 
 const screens = Object.freeze({
@@ -7,7 +8,7 @@ const screens = Object.freeze({
 })
 
 class DeepLinkResolver {
-  acceptedDeepLinks = ["transaction", "block", "epoch", "address", "tx"];
+  acceptedDeepLinks = ["transaction", "block", "epoch", "address", "tx", "governance-action"];
   acceptedNetworks = ["preprod", "preview"]; // mainnet is default
 
 
@@ -37,6 +38,9 @@ class DeepLinkResolver {
           break;
         case "address":
           this.query.set("address", pathSplit[pathSplit.length - 1]);
+          break;
+        case "governance-action":
+          this.query.set("governance-action", pathSplit[pathSplit.length - 1]);
           break;
         default:
           console.log("Unknown mode: " + this.mode);
@@ -74,6 +78,8 @@ class DeepLinkResolver {
       case "address":
         link += `address/${this.getValue()}`;
         break;
+      case "governance-action":
+        return null;
     }
     return link;
   }
@@ -97,6 +103,9 @@ class DeepLinkResolver {
       case "address":
         link += `address/${this.getValue()}`;
         break;
+      case "governance-action":
+        link += `govAction/${this.getValue()}`;
+        break;
     }
     return link;
   }
@@ -116,6 +125,9 @@ class DeepLinkResolver {
       case "address":
         link += `addresses/${this.getValue()}`;
         break;
+      case "governance-action":
+        link += `governances/${this.getValue()}`;
+        break;
     }
     return link;
   }
@@ -130,6 +142,17 @@ class DeepLinkResolver {
         return this.query.get("id");
       case "address":
         return this.query.get("address");
+      case "governance-action":
+        // NOTE: If the argument is provided as a bech32-encoded string, we convert it to hexadecimal because
+        // not all explorers handle well gov id as bech32 string, but those who handle gov action handles them
+        // fine in hexadecimal/base16.
+        const value = this.query.get("governance-action");
+        if (value.startsWith(`gov_action1`)) {
+          const words = bech32.fromWords(bech32.decode(value, 999).words);
+          return words.map(word => word.toString(16).padStart(2, "0")).join("");
+        } else {
+          return value;
+        }
     }
   }
 
@@ -143,6 +166,8 @@ class DeepLinkResolver {
         return this.query.has("id");
       case "address":
         return this.query.has("address");
+      case "governance-action":
+        return this.query.has("governance-action");
     }
   }
 
@@ -156,6 +181,23 @@ class DeepLinkResolver {
         return "id";
       case "address":
         return "address";
+      case "governance-action":
+        return "governance-action";
+    }
+  }
+
+  getHumanReadableMode() {
+    switch (this.mode) {
+      case "epoch":
+        return "epoch";
+      case "block":
+        return "block";
+      case "transaction":
+        return "transaction";
+      case "address":
+        return "address";
+      case "governance-action":
+        return "governance action";
     }
   }
 


### PR DESCRIPTION
  Only for AdaStat and CardanoScan, although it's also supported on various other tools that aren't considered 'exploers' here. Note also that while cexplorer as *some support* for displaying governance actions, they are indexed by their number on-chain, which is unpractical as we can't easily resolve that from an id. So I've simply excluded it for now.