### PR TITLE
feat: per-target deeplink modes and DRep deeplink type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,8 @@
       },
       "devDependencies": {
         "@vitejs/plugin-react": "^4.3.1",
-        "vite": "^5.4.0"
+        "vite": "^5.4.0",
+        "vitest": "^2.1.9"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -869,9 +870,10 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.25",
@@ -1534,6 +1536,119 @@
         "vite": "^4.2.0 || ^5.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
@@ -1543,6 +1658,16 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/babel-plugin-macros": {
@@ -1596,6 +1721,16 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -1624,6 +1759,23 @@
         }
       ]
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -1635,6 +1787,16 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/clsx": {
@@ -1698,11 +1860,12 @@
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "node_modules/debug": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
-      "integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -1711,6 +1874,16 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/dom-helpers": {
@@ -1735,6 +1908,13 @@
       "dependencies": {
         "is-arrayish": "^0.2.1"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.21.5",
@@ -1789,6 +1969,26 @@
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/find-root": {
@@ -1949,6 +2149,13 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -1958,10 +2165,21 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/nanoid": {
       "version": "3.3.7",
@@ -2034,6 +2252,23 @@
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
       }
     },
     "node_modules/picocolors": {
@@ -2270,6 +2505,13 @@
       "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
       "license": "MIT"
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -2286,6 +2528,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stylis": {
       "version": "4.2.0",
@@ -2312,6 +2568,50 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-fast-properties": {
@@ -2409,6 +2709,112 @@
         "terser": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/yallist": {

--- a/package.json
+++ b/package.json
@@ -8,13 +8,15 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "serve": "vite preview"
+    "serve": "vite preview",
+    "test": "vitest run"
   },
   "keywords": [],
   "license": "Apache-2.0",
   "devDependencies": {
     "@vitejs/plugin-react": "^4.3.1",
-    "vite": "^5.4.0"
+    "vite": "^5.4.0",
+    "vitest": "^2.1.9"
   },
   "dependencies": {
     "@emotion/react": "^11.13.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -76,6 +76,13 @@ const CardanoExplorer = () => {
   const deepLinkResolver = new DeepLinkResolver(path, query);
   const isDeepLink = deepLinkResolver.isDeepLink(path);
 
+  // An explorer can serve the current deeplink only if it is deeplink-capable and
+  // lists this deeplink type in its `supportedDeepLinks`. Each explorer states its
+  // supported types explicitly, so an opt-in type like `drep` only lights up where
+  // it is listed.
+  const handlesDeepLink = (explorer) =>
+    explorer.isDeepLink && deepLinkResolver.canHandleMode(explorer.supportedDeepLinks);
+
   const listOfExplorers = {
     cExplorer: {
       name: "Cexplorer.io",
@@ -84,6 +91,7 @@ const CardanoExplorer = () => {
       image: cExplorerLogo,
       url: deepLinkResolver.getCExplorerLink("https://cexplorer.io/"),
       isDeepLink: true,
+      supportedDeepLinks: ["transaction", "block", "epoch", "address", "governance-action", "drep"],
       networks: ["preprod", "preview"]
     },
     cardanoScan: {
@@ -93,6 +101,7 @@ const CardanoExplorer = () => {
       url: deepLinkResolver.getCardanoScanLink("https://cardanoscan.io/"),
       image: cardanoScanLogo,
       isDeepLink: true,
+      supportedDeepLinks: ["transaction", "block", "epoch", "address", "governance-action", "drep"],
       networks: ["preprod", "preview"]
     },
     poolPM: {
@@ -119,6 +128,7 @@ const CardanoExplorer = () => {
       url: deepLinkResolver.getAdaStatLink("https://adastat.net/"),
       image: adaStatLogo,
       isDeepLink: true,
+      supportedDeepLinks: ["transaction", "block", "epoch", "address", "governance-action"], // no DRep page
       networks: [] // Preprod and preview currently in progress
     },
     poolTool: {
@@ -137,7 +147,7 @@ const CardanoExplorer = () => {
   const sortedExplorers = Object.entries(listOfExplorers).sort((a,b) => 0.5 - Math.random());
   // sorting explorers based on if they are deeplink capable and if they support the requested network
   if (deepLinkResolver.isKnownDeeplink() || deepLinkResolver.network !== null) {
-    sortedExplorers.sort(([, a], [, b]) => (b.isDeepLink && deepLinkResolver.canHandleNetwork(b.networks)) - (a.isDeepLink && deepLinkResolver.canHandleNetwork(a.networks)));
+    sortedExplorers.sort(([, a], [, b]) => (handlesDeepLink(b) && deepLinkResolver.canHandleNetwork(b.networks)) - (handlesDeepLink(a) && deepLinkResolver.canHandleNetwork(a.networks)));
   }
 
   // Auto-select and redirect if user has a preference for this deeplink type and network
@@ -154,7 +164,7 @@ const CardanoExplorer = () => {
     const preferred = localStorage.getItem(prefKey);
     if (preferred && listOfExplorers[preferred]) {
       const explorer = listOfExplorers[preferred];
-      if (explorer.isDeepLink && deepLinkResolver.canHandleNetwork(explorer.networks)) {
+      if (handlesDeepLink(explorer) && deepLinkResolver.canHandleNetwork(explorer.networks)) {
         window.location.href = `${explorer.url}${query.get("value") || ""}`;
       }
     }
@@ -184,9 +194,9 @@ const CardanoExplorer = () => {
         >
           <StyledCard
             sx={{
-              // blurring explorer which can't handle the requested network and are not deeplink capable
-              opacity: (deepLinkResolver.isKnownDeeplink() && !explorer.isDeepLink) || !deepLinkResolver.canHandleNetwork(explorer.networks) ? 0.5 : 1,
-              boxShadow: (deepLinkResolver.isKnownDeeplink() && !explorer.isDeepLink) || !deepLinkResolver.canHandleNetwork(explorer.networks) ? 0 : 4,
+              // blurring explorer which can't handle the requested deeplink type or network
+              opacity: (deepLinkResolver.isKnownDeeplink() && !handlesDeepLink(explorer)) || !deepLinkResolver.canHandleNetwork(explorer.networks) ? 0.5 : 1,
+              boxShadow: (deepLinkResolver.isKnownDeeplink() && !handlesDeepLink(explorer)) || !deepLinkResolver.canHandleNetwork(explorer.networks) ? 0 : 4,
             }}
           >
             <CardMedia
@@ -212,10 +222,10 @@ const CardanoExplorer = () => {
                   {explorer.name}
                 </Typography>
                 {deepLinkResolver.isKnownDeeplink() && (<Chip
-                  color={!explorer.isDeepLink || !deepLinkResolver.canHandleNetwork(explorer.networks) ? "default" : "success"}
+                  color={!handlesDeepLink(explorer) || !deepLinkResolver.canHandleNetwork(explorer.networks) ? "default" : "success"}
                   icon={<LinkIcon />}
                   label={
-                    !explorer.isDeepLink || !deepLinkResolver.canHandleNetwork(explorer.networks)
+                    !handlesDeepLink(explorer) || !deepLinkResolver.canHandleNetwork(explorer.networks)
                       ? "link not available"
                       : "link available"
                   }

--- a/src/common/DeepLinkResolver.jsx
+++ b/src/common/DeepLinkResolver.jsx
@@ -8,7 +8,7 @@ const screens = Object.freeze({
 })
 
 class DeepLinkResolver {
-  acceptedDeepLinks = ["transaction", "block", "epoch", "address", "tx", "governance-action"];
+  acceptedDeepLinks = ["transaction", "block", "epoch", "address", "tx", "governance-action", "drep"];
   acceptedNetworks = ["preprod", "preview"]; // mainnet is default
 
 
@@ -41,6 +41,9 @@ class DeepLinkResolver {
           break;
         case "governance-action":
           this.query.set("governance-action", pathSplit[pathSplit.length - 1]);
+          break;
+        case "drep":
+          this.query.set("drep", pathSplit[pathSplit.length - 1]);
           break;
         default:
           console.log("Unknown mode: " + this.mode);
@@ -80,6 +83,10 @@ class DeepLinkResolver {
         break;
       case "governance-action":
         link += `gov/action?search=${this.getValue(true)}`;
+        break;
+      case "drep":
+        link += `drep/${this.getValue()}`;
+        break;
     }
     return link;
   }
@@ -105,6 +112,9 @@ class DeepLinkResolver {
         break;
       case "governance-action":
         link += `govAction/${this.getValue()}`;
+        break;
+      case "drep":
+        link += `drep/${this.getValue()}`;
         break;
     }
     return link;
@@ -153,6 +163,10 @@ class DeepLinkResolver {
         } else {
           return value;
         }
+      case "drep":
+        // DReps are forwarded as-is (bech32 drep1...); the explorers that expose a
+        // DRep page resolve the bech32 id directly.
+        return this.query.get("drep");
     }
   }
 
@@ -168,6 +182,8 @@ class DeepLinkResolver {
         return this.query.has("address");
       case "governance-action":
         return this.query.has("governance-action");
+      case "drep":
+        return this.query.has("drep");
     }
   }
 
@@ -183,6 +199,8 @@ class DeepLinkResolver {
         return "address";
       case "governance-action":
         return "governance-action";
+      case "drep":
+        return "drep";
     }
   }
 
@@ -198,6 +216,8 @@ class DeepLinkResolver {
         return "address";
       case "governance-action":
         return "governance action";
+      case "drep":
+        return "DRep";
     }
   }
 
@@ -207,6 +227,14 @@ class DeepLinkResolver {
 
   canHandleNetwork(networks) {
     return this.network === undefined || this.network === null || networks.includes(this.network);
+  }
+
+  // Some explorers only support a subset of deeplink types (e.g. a governance
+  // tool that resolves DReps and governance actions but not transactions). Each
+  // explorer states the types it supports in its `supportedDeepLinks` list; there
+  // is no implicit fallback, so a new opt-in type only lights up where it is listed.
+  canHandleMode(supportedDeepLinks) {
+    return (supportedDeepLinks ?? []).includes(this.mode);
   }
 
   isDeepLink(path) {

--- a/src/common/DeepLinkResolver.test.js
+++ b/src/common/DeepLinkResolver.test.js
@@ -1,0 +1,161 @@
+import { describe, it, expect } from "vitest";
+import DeepLinkResolver from "./DeepLinkResolver.jsx";
+
+// Build a resolver the way App.jsx does: a pathname plus URL search params.
+const make = (path, qs = "") => new DeepLinkResolver(path, new URLSearchParams(qs));
+
+// A real governance action id and its base16 form (index byte included). The
+// hex was derived independently from the bech32 via the `bech32` lib so this
+// test pins the conversion rather than re-deriving it from the same code path.
+const GOV_BECH = "gov_action1jxne7hynfd7frcczwumd2eggps4kvy0msjztz9t0mutpy870ksgqqp6vp3p";
+const GOV_HEX = "91a79f5c934b7c91e3027736d565080c2b6611fb8484b1156fdf16121fcfb41000";
+const DREP = "drep1ygqzg3ed7rdqeg3343jw0fptqzc3lqtk3rvnnmgq64rj85sxd4sr4";
+
+const CEXPLORER = "https://cexplorer.io/";
+const CARDANOSCAN = "https://cardanoscan.io/";
+const ADASTAT = "https://adastat.net/";
+
+// Exact links every explorer must produce per deeplink type. The pre-`drep`
+// rows lock the existing behaviour so the change cannot regress them; the
+// `drep` rows cover the new type.
+const cases = [
+  {
+    mode: "epoch",
+    path: "/epoch/42",
+    cexplorer: "https://cexplorer.io/epoch/42",
+    cardanoscan: "https://cardanoscan.io/epoch/42",
+    adastat: "https://adastat.net/epochs/42",
+  },
+  {
+    mode: "block",
+    path: "/block/12345",
+    cexplorer: "https://cexplorer.io/block?search=block_no%3A12345",
+    cardanoscan: "https://cardanoscan.io/block/12345",
+    adastat: "https://adastat.net/blocks/12345",
+  },
+  {
+    mode: "transaction",
+    path: "/transaction/deadbeef",
+    cexplorer: "https://cexplorer.io/tx/deadbeef",
+    cardanoscan: "https://cardanoscan.io/transaction/deadbeef",
+    adastat: "https://adastat.net/transactions/deadbeef",
+  },
+  {
+    mode: "address",
+    path: "/address/addr1xyz",
+    cexplorer: "https://cexplorer.io/address/addr1xyz",
+    cardanoscan: "https://cardanoscan.io/address/addr1xyz",
+    adastat: "https://adastat.net/addresses/addr1xyz",
+  },
+  {
+    mode: "governance-action",
+    path: `/governance-action/${GOV_BECH}`,
+    // cExplorer keeps the bech32 form; the others use the hex form.
+    cexplorer: `https://cexplorer.io/gov/action?search=${GOV_BECH}`,
+    cardanoscan: `https://cardanoscan.io/govAction/${GOV_HEX}`,
+    adastat: `https://adastat.net/governances/${GOV_HEX}`,
+  },
+  {
+    mode: "drep",
+    path: `/drep/${DREP}`,
+    cexplorer: `https://cexplorer.io/drep/${DREP}`,
+    cardanoscan: `https://cardanoscan.io/drep/${DREP}`,
+    // AdaStat has no DRep page, so its builder leaves the base link untouched.
+    adastat: "https://adastat.net/",
+  },
+];
+
+describe("link builders per deeplink type", () => {
+  for (const c of cases) {
+    it(`${c.mode}: builds the exact link for every explorer`, () => {
+      const r = make(c.path);
+      expect(r.mode).toBe(c.mode);
+      expect(r.getCExplorerLink(CEXPLORER)).toBe(c.cexplorer);
+      expect(r.getCardanoScanLink(CARDANOSCAN)).toBe(c.cardanoscan);
+      expect(r.getAdaStatLink(ADASTAT)).toBe(c.adastat);
+    });
+  }
+});
+
+describe("network prefixing is unchanged and applies to drep", () => {
+  it("prefixes preprod for the existing gov-action type", () => {
+    const r = make(`/preprod/governance-action/${GOV_BECH}`);
+    expect(r.network).toBe("preprod");
+    expect(r.getCExplorerLink(CEXPLORER)).toBe(`https://preprod.cexplorer.io/gov/action?search=${GOV_BECH}`);
+    expect(r.getCardanoScanLink(CARDANOSCAN)).toBe(`https://preprod.cardanoscan.io/govAction/${GOV_HEX}`);
+  });
+
+  it("prefixes preprod for the new drep type", () => {
+    const r = make(`/preprod/drep/${DREP}`);
+    expect(r.network).toBe("preprod");
+    expect(r.getCExplorerLink(CEXPLORER)).toBe(`https://preprod.cexplorer.io/drep/${DREP}`);
+    expect(r.getCardanoScanLink(CARDANOSCAN)).toBe(`https://preprod.cardanoscan.io/drep/${DREP}`);
+  });
+
+  it("prefixes via ?network=preview too", () => {
+    const r = make(`/drep/${DREP}`, "network=preview");
+    expect(r.network).toBe("preview");
+    expect(r.getCardanoScanLink(CARDANOSCAN)).toBe(`https://preview.cardanoscan.io/drep/${DREP}`);
+  });
+});
+
+describe("tx alias still normalises to transaction", () => {
+  it("maps /tx/<id> to the transaction links", () => {
+    const r = make("/tx/deadbeef");
+    expect(r.mode).toBe("transaction");
+    expect(r.getCardanoScanLink(CARDANOSCAN)).toBe("https://cardanoscan.io/transaction/deadbeef");
+  });
+});
+
+describe("drep parsing (path and query forms)", () => {
+  it("reads the id from the path form", () => {
+    const r = make(`/drep/${DREP}`);
+    expect(r.getValue()).toBe(DREP);
+    expect(r.isCorrectPathVariable()).toBe(true);
+  });
+
+  it("reads the id from the query form", () => {
+    const r = make("/drep", `drep=${DREP}`);
+    expect(r.mode).toBe("drep");
+    expect(r.getValue()).toBe(DREP);
+    expect(r.isCorrectPathVariable()).toBe(true);
+  });
+
+  it("reports a missing variable when the query form lacks the drep param", () => {
+    // Query form carrying an unrelated param: the drep id is absent, matching how
+    // the other modes flag a missing path variable.
+    const r = make("/drep", "foo=bar");
+    expect(r.isCorrectPathVariable()).toBe(false);
+  });
+
+  it("exposes drep metadata", () => {
+    const r = make(`/drep/${DREP}`);
+    expect(r.isKnownDeeplink()).toBe(true);
+    expect(r.getCorrectPathVariable()).toBe("drep");
+    expect(r.getHumanReadableMode()).toBe("DRep");
+  });
+});
+
+describe("canHandleMode gates each explorer to exactly its declared types", () => {
+  it("supports only the listed deeplink types (AdaStat: classic types, no drep)", () => {
+    const adaStat = ["transaction", "block", "epoch", "address", "governance-action"];
+    for (const mode of adaStat) {
+      const path = mode === "governance-action" ? `/governance-action/${GOV_BECH}` : `/${mode}/x`;
+      expect(make(path).canHandleMode(adaStat)).toBe(true);
+    }
+    expect(make(`/drep/${DREP}`).canHandleMode(adaStat)).toBe(false);
+  });
+
+  it("has no implicit fallback: an explorer with no list supports nothing", () => {
+    expect(make("/transaction/x").canHandleMode(undefined)).toBe(false);
+    expect(make(`/drep/${DREP}`).canHandleMode(undefined)).toBe(false);
+  });
+
+  it("gates an explorer to exactly its declared types", () => {
+    const full = ["transaction", "block", "epoch", "address", "governance-action", "drep"];
+    expect(make(`/drep/${DREP}`).canHandleMode(full)).toBe(true);
+    expect(make(`/drep/${DREP}`).canHandleMode(["governance-action"])).toBe(false);
+    expect(make("/transaction/x").canHandleMode(["governance-action", "drep"])).toBe(false);
+    expect(make("/transaction/x").canHandleMode(full)).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #30.

The switcher assumed every explorer is general-purpose. This adds a per-explorer capability so a card is only offered for the deeplink types it actually supports, and introduces a `drep` deeplink type.

## Changes

- Add a per-explorer `modes` list. A card is only offered (chip, blur, sorting, auto-redirect) for the deeplink types the explorer supports, mirroring the existing `canHandleNetwork` gating. Explorers without a `modes` list fall back to the pre-existing set, so their behaviour is unchanged.
- Add a `drep` deeplink type (`/drep/{id}` and `/drep?drep={id}`), wired for Cardanoscan and Cexplorer, which both have a DRep page at `/drep/{id}`. DReps are forwarded as bech32 (`drep1...`), the form both resolve directly. AdaStat has no DRep page, so it is correctly shown as unavailable for `drep`.
- Add a vitest suite for `DeepLinkResolver` (`npm test`). Every explorer link builder is pinned per deeplink type, so the existing epoch/block/transaction/address/governance-action links cannot regress; the new `drep` cases and the mode gating are covered too.

## DRep id form

This uses bech32 `drep1...` as raised in #30. If hex is preferred, it is a one-line change in `getValue`.

## Verification

- `npm test` (16 tests) and `npm run build` pass.
- Manually checked on the dev server: `drep` lights up only Cardanoscan and Cexplorer with correct `/drep/{id}` links; `transaction`, `governance-action` (mainnet and preprod) produce byte-identical links and card states to before, including AdaStat via the fallback.
