### PR TITLE
fix: resolve governance-action deeplink on the documented ?id= query form

### DIFF
--- a/src/common/DeepLinkResolver.jsx
+++ b/src/common/DeepLinkResolver.jsx
@@ -156,8 +156,11 @@ class DeepLinkResolver {
         // NOTE: If the argument is provided as a bech32-encoded string, we convert it to hexadecimal because
         // not all explorers handle well gov id as bech32 string, but those who handle gov action handles them
         // fine in hexadecimal/base16.
-        const value = this.query.get("governance-action");
-        if (value.startsWith(`gov_action1`) && !convert) {
+        // The id can arrive via the documented `id` query param (e.g. ?id=gov_action1...) as well
+        // as the `governance-action` key the path form uses. Guard the null so a missing/malformed
+        // value never throws (which would blank the whole page).
+        const value = this.query.get("governance-action") ?? this.query.get("id");
+        if (value && value.startsWith(`gov_action1`) && !convert) {
           const words = bech32.fromWords(bech32.decode(value).words);
           return words.map(word => word.toString(16).padStart(2, "0")).join("");
         } else {
@@ -181,7 +184,7 @@ class DeepLinkResolver {
       case "address":
         return this.query.has("address");
       case "governance-action":
-        return this.query.has("governance-action");
+        return this.query.has("governance-action") || this.query.has("id");
       case "drep":
         return this.query.has("drep");
     }

--- a/src/common/DeepLinkResolver.test.js
+++ b/src/common/DeepLinkResolver.test.js
@@ -159,3 +159,30 @@ describe("canHandleMode gates each explorer to exactly its declared types", () =
     expect(make("/transaction/x").canHandleMode(full)).toBe(true);
   });
 });
+
+describe("governance-action deeplink resolves every documented form without crashing", () => {
+  const forms = [
+    ["path form", `/governance-action/${GOV_BECH}`, ""],
+    ["?id= query form (as documented in the help and README)", "/governance-action", `id=${GOV_BECH}`],
+    ["?governance-action= query form", "/governance-action", `governance-action=${GOV_BECH}`],
+  ];
+
+  for (const [label, path, qs] of forms) {
+    it(`${label}: resolves the id`, () => {
+      const r = make(path, qs);
+      expect(r.isCorrectPathVariable()).toBe(true);
+      // bech32 is kept when convert=true (how cExplorer consumes it); hex otherwise.
+      expect(r.getValue(true)).toBe(GOV_BECH);
+      expect(r.getValue()).toBe(GOV_HEX);
+      expect(r.getCardanoScanLink(CARDANOSCAN)).toBe(`https://cardanoscan.io/govAction/${GOV_HEX}`);
+      expect(r.getCExplorerLink(CEXPLORER)).toBe(`https://cexplorer.io/gov/action?search=${GOV_BECH}`);
+    });
+  }
+
+  it("does not throw when the id is absent (guards the null that blanked the page)", () => {
+    const r = make("/governance-action", "foo=bar");
+    expect(() => r.getValue()).not.toThrow();
+    expect(r.getValue()).toBeNull();
+    expect(r.isCorrectPathVariable()).toBe(false);
+  });
+});


### PR DESCRIPTION
The `governance-action` deeplink renders a blank page when opened with the query form the UI documents, e.g. `/governance-action?id=gov_action1...`.

## Cause

`getValue()` reads the `governance-action` query key for this type, but the help popup and README document `?id=`. With `?id=`, the value is `null` and `null.startsWith("gov_action1")` throws, unmounting the app (blank page). The path form `/governance-action/{id}` is unaffected.

## Fix

- Accept the documented `id` query param for governance actions, in addition to the existing `governance-action` key.
- Guard against a missing value so the resolver never calls `startsWith` on `null`.

## Tests

Adds a vitest suite covering the path form, both query forms, and the missing-id guard. `npm test` and `npm run build` pass.

## Reproduce on `main`

Open `/governance-action?id=gov_action1jxne7hynfd7frcczwumd2eggps4kvy0msjztz9t0mutpy870ksgqqp6vp3p` and the page is blank; the console shows `Uncaught TypeError: Cannot read properties of null (reading 'startsWith')`.
