### PR TITLE
fix: explorer cards overlap at intermediate widths

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -43,8 +43,9 @@ export const CardLink = styled("a")`
 `;
 
 const StyledCard = styled(Card)(({ theme }) => ({
-  width: 345,
-  height: 300,
+  width: "100%",
+  maxWidth: 345,
+  minHeight: 300,
   backgroundColor: theme.palette.background.paper,
   borderRadius: "12px",
   transition: "transform 0.5s ease-in-out",
@@ -197,7 +198,7 @@ const CardanoExplorer = () => {
 
   const explorerCards = sortedExplorers.map(
     ([key, explorer]) => (
-      <Grid item xs={12} sm={6} md={4} key={key}>
+      <Grid item xs={12} sm={6} md={4} key={key} sx={{ display: "flex" }}>
         <CardLink
           href={`${explorer.url}${query.get("value") || ""}`}
           target="_blank"
@@ -360,8 +361,9 @@ const CardanoExplorer = () => {
                 spacing={3}
                 sx={{
                   display: { xs: "grid", sm: "flex" },
+                  flexWrap: "wrap",
                   justifyContent: "center",
-                  alignItems: "center",
+                  alignItems: "stretch",
                 }}
               >
                 {selectedExplorer ? (


### PR DESCRIPTION
When the window is narrowed, the explorer cards overlapped each other before the grid wrapped to fewer columns.

<img width="600" alt="Screenshot 2026-07-09 at 11 45 14" src="https://github.com/user-attachments/assets/271c6246-43d4-4775-9e23-f067fb0d9049" />


## Cause

Each card had a fixed 345px width. Between breakpoints (roughly 900 to 1000px) the three-column layout gives each card a column narrower than 345px, so the fixed-width cards overflowed and overlapped their neighbours until the next breakpoint.

## Fix

- The card fills its grid column (capped at 345px) instead of using a fixed width, so it never overflows into its neighbour.
- Its height grows with the content instead of being fixed, so nothing is clipped when the text wraps at narrower widths.
- Cards in a row stretch to equal height.

Verified in the browser across widths (480, 750, 902, 910, 971, 1240 px): no overlap, no clipped text, no horizontal scroll, and equal-height cards per row.
